### PR TITLE
Corrects column naming of support url

### DIFF
--- a/src/Entity/ServiceProvider.php
+++ b/src/Entity/ServiceProvider.php
@@ -108,14 +108,14 @@ class ServiceProvider extends AbstractRole
     /**
      * @var null|string
      *
-     * @ORM\Column(name="url_en", type="string", nullable=true)
+     * @ORM\Column(name="support_url_en", type="string", nullable=true)
      */
     public $supportUrlEn;
 
     /**
      * @var null|string
      *
-     * @ORM\Column(name="url_nl", type="string", nullable=true)
+     * @ORM\Column(name="support_url_nl", type="string", nullable=true)
      */
     public $supportUrlNl;
 


### PR DESCRIPTION
When renaming service provider urls properties, column names should have been renamed as well.
