### PR TITLE
Update DoctrineMetadataRepository.php

### DIFF
--- a/src/MetadataRepository/DoctrineMetadataRepository.php
+++ b/src/MetadataRepository/DoctrineMetadataRepository.php
@@ -137,7 +137,7 @@ class DoctrineMetadataRepository extends AbstractMetadataRepository
                 ->andWhere(Criteria::expr()->eq('entityId', $entityId))
         );
 
-        if ($identityProviderCollection->count() === 0) {
+        if (!$identityProviderCollection->count()) {
             return null;
         }
 
@@ -166,7 +166,7 @@ class DoctrineMetadataRepository extends AbstractMetadataRepository
                 ->andWhere(Criteria::expr()->eq('entityId', $entityId))
         );
 
-        if ($serviceProviderCollection->count() === 0) {
+        if (!$serviceProviderCollection->count()) {
             return null;
         }
 


### PR DESCRIPTION
On Ubuntu Xenial (PHP7 and MariaDB) $identityProviderCollection->count() === 0 and $serviceProviderCollection->count() === 0 do not evaluate true in the event that the there is no result in the collection. The easiest way is to check if count() evaluates to something that casts to false in the absence of any result.