### PR TITLE
EngineBlock5 requires specific configuration.

### DIFF
--- a/src/Entity/AbstractRole.php
+++ b/src/Entity/AbstractRole.php
@@ -20,8 +20,9 @@ use SAML2_Const;
  * @SuppressWarnings(PHPMD.TooManyFields)
  *
  * @ORM\Entity
+ * @ORM\ChangeTrackingPolicy("DEFERRED_EXPLICIT")
  * @ORM\Table(
- *      name="sso_provider_roles",
+ *      name="sso_provider_roles_eb5",
  *      uniqueConstraints={
  *          @ORM\UniqueConstraint(
  *              name="idx_sso_provider_roles_entity_id_type",


### PR DESCRIPTION
The changes introduces are a different table name and
a different change detection mechanism. These are
introduced for testing purposes only, and for the following
reasons:
- the different table name is to be able to test EB5 with
  production data, including metadata push, without risking
  the pollution of the EB4 metadata
- The entities are modified in EB4 during runtime. Now that
  other (EB5 internal) entities are persisted, change detection
  notices these changes and attempts to persist the changed
  entities, which fails. By marking these entities to have a
  different change detection mechanism, they are only
  checked for changed values when explicitly persisted, not
  when other entities are persisted.
