### PR TITLE
Remove implicit vo id as EB no longer supports it

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d073ee80a40f402b04b5d39c515b1594",
-    "content-hash": "c454df6d747d4886d84a33f9e891821a",
+    "hash": "536c2c8b09610c13fe3cdd73efcdc5bc",
+    "content-hash": "4a22f33e0bd50edaca8e2a06bb2cfc6f",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -727,16 +727,16 @@
         },
         {
             "name": "simplesamlphp/saml2",
-            "version": "v1.10",
+            "version": "v1.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/simplesamlphp/saml2.git",
-                "reference": "6a4b1eece19b067b17fff718176689b82dc89fb9"
+                "reference": "3f268c25ca5e9748652834faad04525746227ef7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/simplesamlphp/saml2/zipball/6a4b1eece19b067b17fff718176689b82dc89fb9",
-                "reference": "6a4b1eece19b067b17fff718176689b82dc89fb9",
+                "url": "https://api.github.com/repos/simplesamlphp/saml2/zipball/3f268c25ca5e9748652834faad04525746227ef7",
+                "reference": "3f268c25ca5e9748652834faad04525746227ef7",
                 "shasum": ""
             },
             "require": {
@@ -772,7 +772,7 @@
                 }
             ],
             "description": "SAML2 PHP library from SimpleSAMLphp",
-            "time": "2016-09-15 06:14:20"
+            "time": "2016-12-02 12:15:53"
         },
         {
             "name": "symfony/console",
@@ -4010,7 +4010,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.3"
+        "php": ">=5.6,<7"
     },
     "platform-dev": []
 }

--- a/src/Entity/Assembler/JanusPushMetadataAssembler.php
+++ b/src/Entity/Assembler/JanusPushMetadataAssembler.php
@@ -154,13 +154,6 @@ class JanusPushMetadataAssembler
         $properties += $this->setPathFromObject(
             array(
                 $connection,
-                'metadata:coin:implicit_vo_id'
-            ),
-            'implicitVoId'
-        );
-        $properties += $this->setPathFromObject(
-            array(
-                $connection,
                 'metadata:coin:display_unconnected_idps_wayf'
             ),
             'displayUnconnectedIdpsWayf'

--- a/src/Entity/Assembler/JanusRestV1Assembler.php
+++ b/src/Entity/Assembler/JanusRestV1Assembler.php
@@ -105,7 +105,6 @@ class JanusRestV1Assembler
         $arguments = array();
         if (isset($metadata['coin:transparant_issuer']))                    { $arguments['isTransparentIssuer']             = (bool) $metadata['coin:transparant_issuer']; }
         if (isset($metadata['coin:trusted_proxy']))                         { $arguments['isTrustedProxy']                  = (bool) $metadata['coin:trusted_proxy']; }
-        if (isset($metadata['coin:implicit_vo_id']))                        { $arguments['implicitVoId']                    = $metadata['coin:implicit_vo_id']; }
         if (isset($metadata['coin:display_unconnected_idps_wayf']))         { $arguments['displayUnconnectedIdpsWayf']      = (bool) $metadata['coin:display_unconnected_idps_wayf']; }
         if (isset($metadata['coin:no_consent_required']))                   { $arguments['isConsentRequired']               = !(bool) $metadata['coin:no_consent_required']; }
         if (isset($metadata['coin:eula']))                                  { $arguments['termsOfServiceUrl']               = $metadata['coin:eula']; }

--- a/src/Entity/Disassembler/CortoDisassembler.php
+++ b/src/Entity/Disassembler/CortoDisassembler.php
@@ -34,9 +34,6 @@ class CortoDisassembler
         if ($entity->isTransparentIssuer) {
             $cortoEntity['TransparentIssuer'] = 'yes';
         }
-        if ($entity->implicitVoId) {
-            $cortoEntity['VoContext'] = $entity->implicitVoId;
-        }
         if ($entity->displayUnconnectedIdpsWayf) {
             $cortoEntity['DisplayUnconnectedIdpsWayf'] = 'yes';
         }

--- a/src/Entity/ServiceProvider.php
+++ b/src/Entity/ServiceProvider.php
@@ -50,13 +50,6 @@ class ServiceProvider extends AbstractRole
     public $isTrustedProxy;
 
     /**
-     * @var string
-     *
-     * @ORM\Column(name="implicit_vo_id", type="string")
-     */
-    public $implicitVoId;
-
-    /**
      * @var bool
      *
      * @ORM\Column(name="display_unconnected_idps_wayf", type="boolean")
@@ -155,7 +148,6 @@ class ServiceProvider extends AbstractRole
      * @param array $assertionConsumerServices
      * @param bool $displayUnconnectedIdpsWayf
      * @param null $termsOfServiceUrl
-     * @param null $implicitVoId
      * @param bool $isConsentRequired
      * @param bool $isTransparentIssuer
      * @param bool $isTrustedProxy
@@ -200,7 +192,6 @@ class ServiceProvider extends AbstractRole
         array $assertionConsumerServices = array(),
         $displayUnconnectedIdpsWayf = false,
         $termsOfServiceUrl = null,
-        $implicitVoId = null,
         $isConsentRequired = true,
         $isTransparentIssuer = false,
         $isTrustedProxy = false,
@@ -246,7 +237,6 @@ class ServiceProvider extends AbstractRole
         $this->assertionConsumerServices = $assertionConsumerServices;
         $this->displayUnconnectedIdpsWayf = $displayUnconnectedIdpsWayf;
         $this->termsOfServiceUrl = $termsOfServiceUrl;
-        $this->implicitVoId = $implicitVoId;
         $this->isConsentRequired = $isConsentRequired;
         $this->isTransparentIssuer = $isTransparentIssuer;
         $this->isTrustedProxy = $isTrustedProxy;

--- a/tests/Entity/Assembler/JanusRestV1AssemblerTest.php
+++ b/tests/Entity/Assembler/JanusRestV1AssemblerTest.php
@@ -204,7 +204,6 @@ class JanusRestV1AssemblerTest extends PHPUnit_Framework_TestCase
         "coin:do_not_add_attribute_aliases":true,
         "coin:eula":"https://example.edu/eula",
         "coin:gadgetbaseurl":"https://example.edu",
-        "coin:implicit_vo_id":"test",
         "coin:institution_id":"test",
         "coin:is_provision_sp":true,
         "coin:is_provision_sp_groups":true,
@@ -295,7 +294,6 @@ class JanusRestV1AssemblerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($serviceProvider->policyEnforcementDecisionRequired);
         $this->assertTrue($serviceProvider->attributeAggregationRequired);
         $this->assertEquals('https://example.edu/eula', $serviceProvider->termsOfServiceUrl);
-        $this->assertEquals('test', $serviceProvider->implicitVoId);
         $this->assertFalse($serviceProvider->isConsentRequired);
         $this->assertTrue($serviceProvider->publishInEdugain);
         $this->assertEquals('2012-09-01', $serviceProvider->publishInEduGainDate->format('Y-m-d'));

--- a/tests/Entity/Disassembler/CortoDisassemblerTest.php
+++ b/tests/Entity/Disassembler/CortoDisassemblerTest.php
@@ -19,7 +19,6 @@ class CortoDisassemblerTest extends PHPUnit_Framework_TestCase
         $serviceProvider->displayNameEn = 'DisplayName';
         $serviceProvider->isTransparentIssuer = true;
         $serviceProvider->displayUnconnectedIdpsWayf = true;
-        $serviceProvider->implicitVoId = 'implicit';
         $serviceProvider->isConsentRequired = false;
         $serviceProvider->skipDenormalization = true;
         $serviceProvider->policyEnforcementDecisionRequired = true;
@@ -36,7 +35,6 @@ class CortoDisassemblerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($serviceProvider->displayNameNl         , $cortoServiceProvider['DisplayName']['en']);
         $this->assertEquals('yes'                                   , $cortoServiceProvider['TransparentIssuer']);
         $this->assertEquals('yes'                                   , $cortoServiceProvider['DisplayUnconnectedIdpsWayf']);
-        $this->assertEquals($serviceProvider->implicitVoId          , $cortoServiceProvider['VoContext']);
         $this->assertEquals(!$serviceProvider->isConsentRequired    , $cortoServiceProvider['NoConsentRequired']);
         $this->assertEquals($serviceProvider->skipDenormalization   , $cortoServiceProvider['SkipDenormalization']);
         $this->assertEquals($serviceProvider->policyEnforcementDecisionRequired   , $cortoServiceProvider['PolicyEnforcementDecisionRequired']);


### PR DESCRIPTION
[118568103](https://www.pivotaltracker.com/story/show/118568103)
OpenConext/OpenConext-engineblock#356
OpenConext/OpenConext-engineblock#312

VO functionality has been removed from EngineBlock and its database. This PR makes sure Metadata no longer expects that functionality to be present.