### PR TITLE
Support optional 'source' in ARP rules

### DIFF
--- a/tests/AttributeReleasePolicyTest.php
+++ b/tests/AttributeReleasePolicyTest.php
@@ -72,4 +72,69 @@ class AttributeReleasePolicyTest extends PHPUnit_Framework_TestCase
         }
         $this->assertNotNull($e);
     }
+
+    public function testArpWithSources()
+    {
+        $policy = new AttributeReleasePolicy(
+            array(
+                'a' => array('a'),
+                'b' => array(
+                    array(
+                        'value' => 'b',
+                        'source' => 'b',
+                    ),
+                ),
+            )
+        );
+
+        $this->assertEquals(array('a', 'b'), $policy->getAttributeNames());
+        $this->assertTrue($policy->hasAttribute('a'));
+        $this->assertTrue($policy->hasAttribute('b'));
+        $this->assertTrue($policy->isAllowed('a', 'a'));
+        $this->assertTrue($policy->isAllowed('b', 'b'));
+        $this->assertFalse($policy->isAllowed('a', 'b'));
+        $this->assertFalse($policy->isAllowed('b', 'a'));
+    }
+
+    public function testInvalidArpWithSourceSpecification()
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        new AttributeReleasePolicy(
+            array(
+                'b' => array(
+                    array(
+                        'source' => 'b',
+                    ),
+                ),
+            )
+        );
+    }
+
+    public function testAttributesEligibleForAggregation()
+    {
+        $policy = new AttributeReleasePolicy(
+            array(
+                'a' => array('a'),
+                'b' => array(
+                    array(
+                        'value' => 'b',
+                        'source' => 'b',
+                    ),
+                ),
+            )
+        );
+
+        $this->assertEquals(
+            array(
+                'b' => array(
+                    array(
+                        'value' => 'b',
+                        'source' => 'b',
+                    ),
+                ),
+            ),
+            $policy->getRulesWithSourceSpecification()
+        );
+    }
 }


### PR DESCRIPTION
Data in ARP is structured in an associative array:

    attribute name => [ list of value rules ]

We now support storing an optional source for each attribute:

    attribute name => [
        [
            value => '...'
            source => '...'
        ]
    ]

Sources have no effect on the enforcement of the policy. For example,
consider the following hypothetical situation:

  - when an ARP specifies the attribute 'eduPersonOrcid' should be
    included from 'source1'

  - but the aggregator returns no eduPersonOrcid attribute, while the
    IdP does return the attribute

In those cases then the attribute will be included in the SAML response
because the source is not considered when matching attributes.