### PR TITLE
Make sure WAYF visibility is reflected correctly

### DIFF
--- a/src/MetadataRepository/DoctrineMetadataRepository.php
+++ b/src/MetadataRepository/DoctrineMetadataRepository.php
@@ -196,9 +196,18 @@ class DoctrineMetadataRepository extends AbstractMetadataRepository
      */
     public function findIdentityProviders()
     {
-        return $this->idpRepository->matching(
+        $identityProviders = $this->idpRepository->matching(
             $this->compositeFilter->toCriteria($this->idpRepository->getClassName())
         )->toArray();
+
+        foreach ($identityProviders as $identityProvider) {
+            if (!$identityProvider instanceof IdentityProvider) {
+                throw new RuntimeException('Non-IdentityProvider found');
+            }
+            $identityProvider->accept($this->compositeVisitor);
+        }
+
+        return $identityProviders;
     }
 
     /**

--- a/tests/MetadataRepository/DoctrineMetadataRepositoryTest.php
+++ b/tests/MetadataRepository/DoctrineMetadataRepositoryTest.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Mockery;
 use OpenConext\Component\EngineBlockMetadata\Entity\IdentityProvider;
+use OpenConext\Component\EngineBlockMetadata\MetadataRepository\Visitor\DisableDisallowedEntitiesInWayfVisitor;
 use PHPUnit_Framework_TestCase;
 
 /**
@@ -31,5 +32,39 @@ class DoctrineMetadataRepositoryTest extends PHPUnit_Framework_TestCase
         );
 
         $this->assertCount(1, $repository->findIdentityProviders());
+    }
+
+    public function testFindIdentityProvidersVisitor()
+    {
+        $mockSpRepository = Mockery::mock('Doctrine\ORM\EntityRepository');
+        $mockIdpRepository = Mockery::mock('Doctrine\ORM\EntityRepository');
+        $mockIdpRepository
+            ->shouldReceive('getClassName')
+            ->andReturn('OpenConext\Component\EngineBlockMetadata\Entity\IdentityProvider')
+            ->shouldReceive('matching')
+            ->andReturn(new ArrayCollection(array(
+                new IdentityProvider('https://idp.entity.com'),
+                new IdentityProvider('https://unconnected.entity.com')
+            )));
+
+        $repository = new DoctrineMetadataRepository(
+            Mockery::mock('Doctrine\ORM\EntityManager'),
+            $mockSpRepository,
+            $mockIdpRepository
+        );
+
+        $repository->appendVisitor(new DisableDisallowedEntitiesInWayfVisitor(['https://idp.entity.com']));
+        $identityProviders = $repository->findIdentityProviders();
+
+        $expectedWayfVisibility = [
+            'https://idp.entity.com' => true,
+            'https://unconnected.entity.com' => false,
+        ];
+
+        foreach ($identityProviders as $identityProvider){
+            $this->assertEquals($expectedWayfVisibility[$identityProvider->entityId], $identityProvider->enabledInWayf);
+        }
+
+        $this->assertCount(2, $identityProviders);
     }
 }


### PR DESCRIPTION
When the Show unconnected IdP's in WAYF flag is enabled the unconnected
should be displayed in the WAYF and not be filtered. In this commit the
`findIdentityProviders` method for the DoctrineMetadataRepository makes
sure it's results are visited by the Visitor implementation for IdPs.

Main question is: does this change break other behaviour for the other methods that call and use this method. My gut feel tells me this change would only affect parts of the application that use the `IdentityProvider::$isEnabledInWayf` property, so this change is quite safe..