### PR TITLE
Add support for contact person telephone numbers

### DIFF
--- a/src/ContactPerson.php
+++ b/src/ContactPerson.php
@@ -10,6 +10,7 @@ class ContactPerson
 {
     public $contactType;
     public $emailAddress = '';
+    public $telephoneNumber = '';
     public $givenName = '';
     public $surName = '';
 

--- a/src/Entity/Assembler/JanusPushMetadataAssembler.php
+++ b/src/Entity/Assembler/JanusPushMetadataAssembler.php
@@ -336,6 +336,9 @@ class JanusPushMetadataAssembler
             if (!empty($contactMetadata->emailAddress)) {
                 $contactPerson->emailAddress = $contactMetadata->emailAddress;
             }
+            if (!empty($contactMetadata->telephoneNumber)) {
+                $contactPerson->telephoneNumber = $contactMetadata->telephoneNumber;
+            }
             if (!empty($contactMetadata->givenName)) {
                 $contactPerson->givenName = $contactMetadata->givenName;
             }

--- a/src/Entity/Assembler/JanusRestV1Assembler.php
+++ b/src/Entity/Assembler/JanusRestV1Assembler.php
@@ -347,6 +347,7 @@ class JanusRestV1Assembler
             if ($contactType) {
                 $contactPerson = new ContactPerson($contactType);
                 $contactPerson->emailAddress = Utils::ifsetor($metadata, "contacts:$i:emailAddress", '');
+                $contactPerson->telephoneNumber = Utils::ifsetor($metadata, "contacts:$i:telephoneNumber", '');
                 $contactPerson->givenName    = Utils::ifsetor($metadata, "contacts:$i:givenName", '');
                 $contactPerson->surName      = Utils::ifsetor($metadata, "contacts:$i:surName", '');
                 $contactPersons[] = $contactPerson;

--- a/src/Entity/Disassembler/CortoDisassembler.php
+++ b/src/Entity/Disassembler/CortoDisassembler.php
@@ -301,6 +301,7 @@ class CortoDisassembler
             $cortoEntity['ContactPersons'][] = array(
                 'ContactType' => $contactPerson->contactType,
                 'EmailAddress' => $contactPerson->emailAddress,
+                'TelephoneNumber' => $contactPerson->telephoneNumber,
                 'GivenName' => $contactPerson->givenName,
                 'SurName' => $contactPerson->surName,
             );

--- a/tests/Entity/Assembler/JanusRestV1AssemblerTest.php
+++ b/tests/Entity/Assembler/JanusRestV1AssemblerTest.php
@@ -175,7 +175,7 @@ class JanusRestV1AssemblerTest extends PHPUnit_Framework_TestCase
             . 'pqPmXOGde+uXC4ipk9GXHm7ZVTYCOuPKMoLk87H6yzRqoVe1XZvYY9dYIT0YJxxj'
             . 'bLAetQmU33PYPOJWfnKzRLQI5yNQgWFAKf9KTcc6N2gI6NkB3CHqMwcH0mdapriq'
             . '+lCiaVxdZw==';
-        
+
         $entity = json_decode('{
         "AssertionConsumerService:0:Binding":"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
         "AssertionConsumerService:0:index":0,

--- a/tests/Entity/Disassembler/CortoDisassemblerTest.php
+++ b/tests/Entity/Disassembler/CortoDisassemblerTest.php
@@ -2,6 +2,7 @@
 
 namespace OpenConext\Component\EngineBlockMetadata\Entity\Disassembler;
 
+use OpenConext\Component\EngineBlockMetadata\ContactPerson;
 use OpenConext\Component\EngineBlockMetadata\Entity\IdentityProvider;
 use OpenConext\Component\EngineBlockMetadata\Entity\ServiceProvider;
 use PHPUnit_Framework_TestCase;
@@ -24,6 +25,12 @@ class CortoDisassemblerTest extends PHPUnit_Framework_TestCase
         $serviceProvider->policyEnforcementDecisionRequired = true;
         $serviceProvider->attributeAggregationRequired = true;
 
+        $contact = new ContactPerson('support');
+        $contact->emailAddress = 't@t.t';
+        $contact->telephoneNumber = '0611';
+
+        $serviceProvider->contactPersons[] = $contact;
+
         $disassembler = new CortoDisassembler();
         $cortoServiceProvider = $disassembler->translateServiceProvider($serviceProvider);
 
@@ -39,11 +46,20 @@ class CortoDisassemblerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($serviceProvider->skipDenormalization   , $cortoServiceProvider['SkipDenormalization']);
         $this->assertEquals($serviceProvider->policyEnforcementDecisionRequired   , $cortoServiceProvider['PolicyEnforcementDecisionRequired']);
         $this->assertEquals($serviceProvider->attributeAggregationRequired        , $cortoServiceProvider['AttributeAggregationRequired']);
+        $this->assertEquals($contact->contactType, $cortoServiceProvider['ContactPersons'][0]['ContactType']);
+        $this->assertEquals($contact->emailAddress, $cortoServiceProvider['ContactPersons'][0]['EmailAddress']);
+        $this->assertEquals($contact->telephoneNumber, $cortoServiceProvider['ContactPersons'][0]['TelephoneNumber']);
     }
 
     public function testIdpDisassemble()
     {
         $identityProvider = new IdentityProvider('https://idp.example.edu');
+
+        $contact = new ContactPerson('support');
+        $contact->emailAddress = 't@t.t';
+        $contact->telephoneNumber = '0611';
+
+        $identityProvider->contactPersons[] = $contact;
 
         $disassembler = new CortoDisassembler();
         $cortoIdentityProvider = $disassembler->translateIdentityProvider($identityProvider);
@@ -56,5 +72,8 @@ class CortoDisassemblerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($identityProvider->spsEntityIdsWithoutConsent, $cortoIdentityProvider['SpsWithoutConsent']);
         $this->assertEquals($identityProvider->hidden, $cortoIdentityProvider['isHidden']);
         $this->assertEmpty($cortoIdentityProvider['shibmd:scopes']);
+        $this->assertEquals($contact->contactType, $cortoIdentityProvider['ContactPersons'][0]['ContactType']);
+        $this->assertEquals($contact->emailAddress, $cortoIdentityProvider['ContactPersons'][0]['EmailAddress']);
+        $this->assertEquals($contact->telephoneNumber, $cortoIdentityProvider['ContactPersons'][0]['TelephoneNumber']);
     }
 }


### PR DESCRIPTION
The telephone number of the support contact of an identity provider
should be shown on the consent page. This commit prepares the metadata
library to parse the "contacts:%d:telephoneNumber" and assign it to
the contact entity.