### PR TITLE
Load source from attribute rules for given attribute name

### DIFF
--- a/src/AttributeReleasePolicy.php
+++ b/src/AttributeReleasePolicy.php
@@ -172,4 +172,18 @@ class AttributeReleasePolicy
 
         return (string) $rule;
     }
+
+    /**
+     * Loads the first source it finds in the list of attribute rules for the given attributeName.
+     *
+     * @param $attributeName
+     * @return string
+     */
+    public function getSource($attributeName)
+    {
+        if ($this->hasAttribute($attributeName) && isset($this->attributeRules[$attributeName][0]['source'])) {
+            return $this->attributeRules[$attributeName][0]['source'];
+        }
+        return 'idp';
+    }
 }

--- a/tests/AttributeReleasePolicyTest.php
+++ b/tests/AttributeReleasePolicyTest.php
@@ -142,4 +142,27 @@ class AttributeReleasePolicyTest extends PHPUnit_Framework_TestCase
             $policy->getRulesWithSourceSpecification()
         );
     }
+    public function testGetSource()
+    {
+        $policy = new AttributeReleasePolicy(
+            array(
+                'a' => array('a'),
+                'b' => array(
+                    array(
+                        'value' => 'b',
+                        'source' => 'b',
+                    ),
+                ),
+                'c' => array(
+                    array(
+                        'value' => 'c',
+                    ),
+                ),
+            )
+        );
+
+        $this->assertEquals('idp', $policy->getSource('a'), 'Default source should equal idp');
+        $this->assertEquals('b', $policy->getSource('b'));
+        $this->assertEquals('idp', $policy->getSource('c'), 'Default source should equal idp');
+    }
 }


### PR DESCRIPTION
Adds the getSource method to the `\OpenConext\Component\EngineBlockMetadata\AttributeReleasePolicy` class