### PR TITLE
Support coin:signature method metadata property

### DIFF
--- a/src/Entity/AbstractRole.php
+++ b/src/Entity/AbstractRole.php
@@ -12,6 +12,7 @@ use OpenConext\Component\EngineBlockMetadata\ContactPerson;
 use OpenConext\Component\EngineBlockMetadata\Service;
 use OpenConext\Component\EngineBlockMetadata\X509\X509Certificate;
 use SAML2_Const;
+use XMLSecurityKey;
 
 /**
  * Abstract base class for configuration entities.
@@ -232,6 +233,13 @@ abstract class AbstractRole
     /**
      * @var string
      *
+     * @ORM\Column(name="signature_method", type="string")
+     */
+    public $signatureMethod;
+
+    /**
+     * @var string
+     *
      * @ORM\Column(name="response_processing_service_binding", type="string", nullable=true)
      */
     public $responseProcessingService;
@@ -266,6 +274,7 @@ abstract class AbstractRole
      * @param null $publishInEduGainDate
      * @param bool $publishInEdugain
      * @param bool $requestsMustBeSigned
+     * @param string $signatureMethod
      * @param Service $responseProcessingService
      * @param string $workflowState
      * @param string $manipulation
@@ -296,6 +305,7 @@ abstract class AbstractRole
         $publishInEduGainDate = null,
         $publishInEdugain = false,
         $requestsMustBeSigned = false,
+        $signatureMethod = XMLSecurityKey::RSA_SHA1,
         Service $responseProcessingService = null,
         $workflowState = self::WORKFLOW_STATE_DEFAULT,
         $manipulation = ''
@@ -321,6 +331,7 @@ abstract class AbstractRole
         $this->publishInEduGainDate = $publishInEduGainDate;
         $this->publishInEdugain = $publishInEdugain;
         $this->requestsMustBeSigned = $requestsMustBeSigned;
+        $this->signatureMethod = $signatureMethod;
         $this->responseProcessingService = $responseProcessingService;
         $this->singleLogoutService = $singleLogoutService;
         $this->workflowState = $workflowState;

--- a/src/Entity/Assembler/JanusPushMetadataAssembler.php
+++ b/src/Entity/Assembler/JanusPushMetadataAssembler.php
@@ -243,6 +243,7 @@ class JanusPushMetadataAssembler
         $properties += $this->assemblePublishInEdugainDate($connection);
         $properties += $this->setPathFromObject(array($connection, 'metadata:coin:disable_scoping'), 'disableScoping');
         $properties += $this->setPathFromObject(array($connection, 'metadata:coin:additional_logging'), 'additionalLogging');
+        $properties += $this->setPathFromObject(array($connection, 'metadata:coin:signature_method'), 'signatureMethod');
         $properties += $this->setPathFromObject(array($connection, 'metadata:redirect:sign'), 'requestsMustBeSigned');
         $properties += $this->setPathFromObject(array($connection, 'manipulation_code'), 'manipulation');
 

--- a/src/Entity/Assembler/JanusRestV1Assembler.php
+++ b/src/Entity/Assembler/JanusRestV1Assembler.php
@@ -78,6 +78,7 @@ class JanusRestV1Assembler
         if (isset($metadata['coin:disable_scoping']))    { $arguments['disableScoping'] = (bool) $metadata['coin:disable_scoping']; }
         if (isset($metadata['coin:additional_logging'])) { $arguments['additionalLogging'] = (bool) $metadata['coin:additional_logging']; }
 
+        if (isset($metadata['coin:signature_method'])) { $arguments['signatureMethod'] = $metadata['coin:signature_method']; }
         if (isset($metadata['redirect.sign'])) { $arguments['requestsMustBeSigned'] = (bool) $metadata['redirect.sign']; }
         if (isset($metadata['NameIDFormat']))  { $arguments['nameIdFormat'] = $metadata['NameIDFormat']; }
         if (isset($metadata['workflowState'])) { $arguments['workflowState'] = $metadata['workflowState']; }

--- a/src/Entity/IdentityProvider.php
+++ b/src/Entity/IdentityProvider.php
@@ -9,6 +9,7 @@ use OpenConext\Component\EngineBlockMetadata\Organization;
 use OpenConext\Component\EngineBlockMetadata\ShibMdScope;
 use OpenConext\Component\EngineBlockMetadata\Service;
 use SAML2_Const;
+use XMLSecurityKey;
 
 /**
  * Class IdentityProvider
@@ -106,6 +107,7 @@ class IdentityProvider extends AbstractRole
      * @param null $publishInEduGainDate
      * @param bool $publishInEdugain
      * @param bool $requestsMustBeSigned
+     * @param string $signatureMethod
      * @param Service $responseProcessingService
      * @param string $workflowState
      * @param bool $enabledInWayf
@@ -142,6 +144,7 @@ class IdentityProvider extends AbstractRole
         $publishInEduGainDate = null,
         $publishInEdugain = false,
         $requestsMustBeSigned = false,
+        $signatureMethod = XMLSecurityKey::RSA_SHA1,
         Service $responseProcessingService = null,
         $workflowState = self::WORKFLOW_STATE_DEFAULT,
         $manipulation = '',
@@ -177,6 +180,7 @@ class IdentityProvider extends AbstractRole
             $publishInEduGainDate,
             $publishInEdugain,
             $requestsMustBeSigned,
+            $signatureMethod,
             $responseProcessingService,
             $workflowState,
             $manipulation

--- a/src/Entity/ServiceProvider.php
+++ b/src/Entity/ServiceProvider.php
@@ -11,6 +11,7 @@ use OpenConext\Component\EngineBlockMetadata\IndexedService;
 use OpenConext\Component\EngineBlockMetadata\Service;
 use SAML2_Const;
 use Doctrine\ORM\Mapping as ORM;
+use XMLSecurityKey;
 
 /**
  * Class ServiceProvider
@@ -142,6 +143,7 @@ class ServiceProvider extends AbstractRole
      * @param null $publishInEduGainDate
      * @param bool $publishInEdugain
      * @param bool $requestsMustBeSigned
+     * @param string $signatureMethod
      * @param Service $responseProcessingService
      * @param string $workflowState
      * @param array $allowedIdpEntityIds
@@ -186,6 +188,7 @@ class ServiceProvider extends AbstractRole
         $publishInEduGainDate = null,
         $publishInEdugain = false,
         $requestsMustBeSigned = false,
+        $signatureMethod = XMLSecurityKey::RSA_SHA1,
         Service $responseProcessingService = null,
         $workflowState = self::WORKFLOW_STATE_DEFAULT,
         array $allowedIdpEntityIds = array(),
@@ -227,6 +230,7 @@ class ServiceProvider extends AbstractRole
             $publishInEduGainDate,
             $publishInEdugain,
             $requestsMustBeSigned,
+            $signatureMethod,
             $responseProcessingService,
             $workflowState,
             $manipulation

--- a/tests/Entity/Assembler/JanusRestV1AssemblerTest.php
+++ b/tests/Entity/Assembler/JanusRestV1AssemblerTest.php
@@ -52,6 +52,7 @@ class JanusRestV1AssemblerTest extends PHPUnit_Framework_TestCase
     "logo:0:width": 120,
     "NameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
     "redirect.sign": false,
+    "coin:signature_method":"http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
     "workflowState": "prodaccepted"
 }', true);
 
@@ -98,6 +99,7 @@ class JanusRestV1AssemblerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('https://.png', $serviceProvider->logo->url);
         $this->assertEquals(SAML2_Const::NAMEID_PERSISTENT, $serviceProvider->nameIdFormat);
         $this->assertFalse($serviceProvider->requestsMustBeSigned);
+        $this->assertEquals('http://www.w3.org/2001/04/xmldsig-more#rsa-sha256', $serviceProvider->signatureMethod);
         $this->assertEquals(AbstractRole::WORKFLOW_STATE_PROD, $serviceProvider->workflowState);
     }
 
@@ -124,6 +126,7 @@ class JanusRestV1AssemblerTest extends PHPUnit_Framework_TestCase
             "name:nl":"",
             "OrganizationDisplayName:nl":"",
             "redirect.sign":false,
+            "coin:signature_method":"http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
             "SingleSignOnService:0:Binding":"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
             "SingleSignOnService:0:Location":"",
             "UIInfo:Keywords:en":"",
@@ -147,6 +150,7 @@ class JanusRestV1AssemblerTest extends PHPUnit_Framework_TestCase
         $this->assertNull($identityProvider->organizationEn);
         $this->assertNull($identityProvider->organizationNl);
         $this->assertFalse($identityProvider->requestsMustBeSigned);
+        $this->assertEquals('http://www.w3.org/2001/04/xmldsig-more#rsa-sha256', $identityProvider->signatureMethod);
         $this->assertEmpty($identityProvider->singleSignOnServices);
         $this->assertEmpty($identityProvider->keywordsEn);
         $this->assertEmpty($identityProvider->keywordsNl);
@@ -267,6 +271,7 @@ class JanusRestV1AssemblerTest extends PHPUnit_Framework_TestCase
         "OrganizationURL:en":"https://example.edu",
         "OrganizationURL:nl":"https://example.edu",
         "redirect.sign":true,
+        "coin:signature_method":"http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
         "SingleLogoutService_Binding":"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
         "SingleLogoutService_Location":"https://example.edu",
         "UIInfo:DisplayName:en":"Test",
@@ -323,6 +328,7 @@ class JanusRestV1AssemblerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('https://example.edu', $serviceProvider->organizationEn->url);
         $this->assertEquals('https://example.edu', $serviceProvider->organizationNl->url);
         $this->assertTrue($serviceProvider->requestsMustBeSigned);
+        $this->assertEquals('http://www.w3.org/2001/04/xmldsig-more#rsa-sha256', $serviceProvider->signatureMethod);
         $this->assertEquals(SAML2_Const::BINDING_HTTP_REDIRECT, $serviceProvider->singleLogoutService->binding);
         $this->assertEquals('https://example.edu', $serviceProvider->singleLogoutService->location);
         $this->assertEquals(ServiceProvider::WORKFLOW_STATE_PROD, $serviceProvider->workflowState);


### PR DESCRIPTION
EngineBlock will use this property to determine the signature method
used to sign assertions.

Example service registry configuration:

            'coin:signature_method':
                type: select
                required: false
                select_values:
                    - 'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
                    - 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
                default_allow: true