### PR TITLE
Support combining the push and pull metadata backends

### DIFF
--- a/src/MetadataRepository/CompositeMetadataRepository.php
+++ b/src/MetadataRepository/CompositeMetadataRepository.php
@@ -293,8 +293,13 @@ class CompositeMetadataRepository extends AbstractMetadataRepository
     public function findAllowedIdpEntityIdsForSp(ServiceProvider $serviceProvider)
     {
         $allowed = array();
+
         foreach ($this->orderedRepositories as $repository) {
-            $allowed += $repository->findAllowedIdpEntityIdsForSp($serviceProvider);
+            if ($repository->findServiceProviderByEntityId($serviceProvider->entityId)) {
+                $allowed = $repository->findAllowedIdpEntityIdsForSp($serviceProvider);
+
+                break;
+            }
         }
 
         return array_values(array_unique($allowed));

--- a/tests/MetadataRepository/CompositeMetadataRepositoryTest.php
+++ b/tests/MetadataRepository/CompositeMetadataRepositoryTest.php
@@ -97,7 +97,7 @@ class CompositeMetadataRepositoryTest extends PHPUnit_Framework_TestCase
         $repository = $this->createFilledRepository();
 
         $this->assertEquals(
-            $repository->findAllIdentityProviderEntityIds(),
+            ['https://idp1.example.edu'],
             $repository->findAllowedIdpEntityIdsForSp(new ServiceProvider('https://sp1.example.edu'))
         );
     }


### PR DESCRIPTION
Using both the push and pull matadata backends did not work as
expected. When fetching ARP or entity manipulations, the first backend
that actually has the entity is used. But when fetching the list of
allowed idps of a service provider, all backends were queried and the
combined results were returned. This did not work for the pull backend
because it throws an error when queried about entities it does not
know about.

This commit fixes the issue by never using all backends, but only the
first backend that actually has the entity.